### PR TITLE
Merge Update Command Parser logic to reduce coupling

### DIFF
--- a/src/main/java/seedu/duke/command/BrowseCommand.java
+++ b/src/main/java/seedu/duke/command/BrowseCommand.java
@@ -50,7 +50,7 @@ public class BrowseCommand extends Command {
 
     private static final Logger LOGGER = Logger.getLogger(BrowseCommand.class.getName());
 
-    public BrowseCommand(String description) {
+    public BrowseCommand() {
         this.description = description;
         this.sortType = 0;
         this.order = 1;
@@ -61,12 +61,9 @@ public class BrowseCommand extends Command {
 
     @Override
     public String execute(AnimeData animeData, StorageManager storageManager, User user) throws AniException {
-        setBrowseOptions();
         ArrayList<Anime> usableList = animeData.getAnimeDataList();
-
         assert (sortType < 3) : ASSERT_SORT_TYPE;
         assert (order < 2) : ASSERT_ORDER_TYPE;
-
         sortBrowseList(usableList);
         String result = buildBrowseOutput(usableList);
         setSortType(3);
@@ -95,14 +92,6 @@ public class BrowseCommand extends Command {
         return result.toString();
     }
 
-    private void setBrowseOptions() throws AniException {
-        String[] paramGiven = description.split("-");
-        if (paramGiven.length > 1) {
-            parameterParser(paramGiven);
-            LOGGER.log(Level.INFO, BROWSE_SETTINGS_CHANGED_INFO);
-        }
-    }
-
     private void sortBrowseList(ArrayList<Anime> usableList) {
         if (sortType == ID_SORT && order == ORDER_DESCENDING) {
             LOGGER.log(Level.INFO, SORT_ID_DESCENDING);
@@ -121,76 +110,6 @@ public class BrowseCommand extends Command {
             usableList.sort(Comparator.comparing(Anime::getRating).reversed());
         } else if (sortType == 3) {
             usableList.sort(Comparator.comparing(Anime::getAnimeID));
-        }
-    }
-
-    private void parameterParser(String[] paramGiven) throws AniException {
-        for (String param : paramGiven) {
-            String[] paramParts = param.split(" ");
-            switch (paramParts[0].trim()) {
-            case "": //skip the first empty param
-                break;
-            case SORT_PARAM:
-                paramLengthCheck(paramParts);
-                checkSortType(paramParts);
-                break;
-            case FILTER_PARAM:
-                paramLengthCheck(paramParts);
-                setFilter(paramParts[1]);
-                break;
-            case ORDER_PARAM:
-                paramLengthCheck(paramParts);
-                checkOrderType(paramParts[1]);
-                break;
-            case PAGE_PARAM:
-                paramLengthCheck(paramParts);
-                if (!isInt(paramParts[1].trim())) {
-                    throw new AniException(NON_INTEGER_PROVIDED);
-                }
-                setPage(Integer.parseInt(paramParts[1].trim()));
-                break;
-            default:
-                String invalidParameter = PARAMETER_ERROR_HEADER + param + NOT_RECOGNISED;
-                throw new AniException(invalidParameter);
-            }
-        }
-    }
-
-    private void checkOrderType(String paramField) throws AniException {
-        switch (paramField.trim()) {
-        case ASCENDING_FIELD:
-            setOrder(0);
-            break;
-        case DESCENDING_FIELD:
-            setOrder(1);
-            break;
-        default:
-            String paramFieldError = paramField + INVALID_OPTION;
-            throw new AniException(paramFieldError);
-        }
-    }
-
-    private void checkSortType(String[] paramParts) throws AniException {
-        switch (paramParts[1].trim()) {
-        case NAME_FIELD:
-            setSortType(1);
-            break;
-        case RATING_FIELD:
-            setSortType(2);
-            break;
-        default:
-            String paramFieldError = paramParts[1] + INVALID_OPTION;
-            throw new AniException(paramFieldError);
-        }
-    }
-
-    private void paramLengthCheck(String[] paramParts) throws AniException {
-        if (paramParts.length < 2) {
-            String invalidParameter = PARAMETER_ERROR_HEADER + paramParts[0] + REQUIRE_ADDITIONAL_FIELD;
-            throw new AniException(invalidParameter);
-        } else if (paramParts.length > 2) {
-            String invalidParameter = PARAMETER_ERROR_HEADER + paramParts[0] + TOO_MUCH_FIELDS;
-            throw new AniException(invalidParameter);
         }
     }
 
@@ -222,13 +141,4 @@ public class BrowseCommand extends Command {
         return order;
     }
 
-    /**
-     * Checks if String is a parsable int.
-     *
-     * @param checkStr string to check
-     * @return true if parsable int
-     */
-    public boolean isInt(String checkStr) {
-        return checkStr.matches("-?\\d+(\\.\\d+)?");
-    }
 }

--- a/src/main/java/seedu/duke/command/BrowseCommand.java
+++ b/src/main/java/seedu/duke/command/BrowseCommand.java
@@ -13,20 +13,14 @@ import java.util.logging.Logger;
 
 public class BrowseCommand extends Command {
     protected static final int ANIME_PER_PAGE = 20;
-    protected static final String SORT_PARAM = "s";
-    protected static final String FILTER_PARAM = "f";
-    protected static final String ORDER_PARAM = "o";
     protected static final String PAGE_PARAM = "p";
-    protected static final String ASCENDING_FIELD = "asc";
-    protected static final String DESCENDING_FIELD = "dsc";
-    protected static final String NAME_FIELD = "name";
-    protected static final String RATING_FIELD = "rating";
     protected static final int ID_SORT = 0;
     protected static final int ORDER_DESCENDING = 0;
 
     private int sortType;
     private int order;
     private int page;
+    private int indexToPrint;
     private String filter;
 
     protected static final String LAST_ANIME_WARNING = "Printing Last Anime Series from source";
@@ -35,13 +29,9 @@ public class BrowseCommand extends Command {
     protected static final String OUT_OF_BOUND_PAGE_ERROR = "Invalid Page size!";
     protected static final String PARAMETER_ERROR_HEADER = "Parameter : -";
     protected static final String REQUIRE_ADDITIONAL_FIELD = " requires an additional field";
-    protected static final String TOO_MUCH_FIELDS = " has too much fields";
-    protected static final String INVALID_OPTION = " is not a valid option";
-    protected static final String NOT_RECOGNISED = " is not recognised!";
     protected static final String NON_INTEGER_PROVIDED = "Please specify an Int value for page number!";
     protected static final String ASSERT_SORT_TYPE = "sortType should be < 3";
     protected static final String ASSERT_ORDER_TYPE = "order should be < 2";
-    protected static final String BROWSE_SETTINGS_CHANGED_INFO = "Default values modified";
     protected static final String SORT_ID_DESCENDING = "Sorting by ID descending";
     protected static final String SORT_NAME_ASCENDING = "Sorting by Name Ascending (A to Z)";
     protected static final String SORT_NAME_DESCENDING = "Sorting by Name Descending (Z to A)";
@@ -51,10 +41,11 @@ public class BrowseCommand extends Command {
     private static final Logger LOGGER = Logger.getLogger(BrowseCommand.class.getName());
 
     public BrowseCommand() {
-        this.description = description;
+        this.description = "";
         this.sortType = 0;
         this.order = 1;
         this.page = 1;
+        this.indexToPrint = 1;
         this.filter = "";
         LOGGER.setLevel(Level.WARNING);
     }
@@ -72,12 +63,10 @@ public class BrowseCommand extends Command {
     }
 
     private String buildBrowseOutput(ArrayList<Anime> usableList) throws AniException {
-        int indexToPrint = (page - 1) * 20;
         if (indexToPrint >= usableList.size()) {
             LOGGER.log(Level.WARNING, OUT_OF_BOUND_PAGE_WARNING + indexToPrint);
             throw new AniException(OUT_OF_BOUND_PAGE_ERROR);
         }
-
         StringBuilder result = new StringBuilder();
         for (int i = indexToPrint; i < indexToPrint + ANIME_PER_PAGE; i++) {
             Anime browseAnime = usableList.get(i);
@@ -119,6 +108,7 @@ public class BrowseCommand extends Command {
 
     public void setPage(int page) {
         this.page = Math.max(page, 1);
+        indexToPrint = (page - 1) * 20;
     }
 
     public int getPage() {

--- a/src/main/java/seedu/duke/command/BrowseCommand.java
+++ b/src/main/java/seedu/duke/command/BrowseCommand.java
@@ -45,7 +45,7 @@ public class BrowseCommand extends Command {
         this.sortType = 0;
         this.order = 1;
         this.page = 1;
-        this.indexToPrint = 1;
+        this.indexToPrint = 0;
         this.filter = "";
         LOGGER.setLevel(Level.WARNING);
     }

--- a/src/main/java/seedu/duke/command/SwitchWorkspaceCommand.java
+++ b/src/main/java/seedu/duke/command/SwitchWorkspaceCommand.java
@@ -2,8 +2,8 @@ package seedu.duke.command;
 
 import seedu.duke.anime.AnimeData;
 import seedu.duke.exception.AniException;
-import seedu.duke.human.Workspace;
 import seedu.duke.human.User;
+import seedu.duke.human.Workspace;
 import seedu.duke.storage.StorageManager;
 
 import java.util.logging.Level;
@@ -12,49 +12,27 @@ import java.util.logging.Logger;
 public class SwitchWorkspaceCommand extends Command {
     protected static final String PARAMETER_ERROR_HEADER = "Parameter : -";
     protected static final String REQUIRE_ADDITIONAL_FIELD = " requires an additional field";
-    protected static final String NOT_RECOGNISED = " is not recognised!";
-
     private static final Logger LOGGER = Logger.getLogger(SwitchWorkspaceCommand.class.getName());
-    protected static final String NO_PARAMETER_PROVIDED = "No Parameter provided";
-    protected static final String SWITCH_SUCCESS_HEADER = "Welcome back, ";
+    protected static final String SWITCH_SUCCESS_HEADER = "Workspace changed to ";
 
-    public SwitchWorkspaceCommand(String description) {
+    protected String switchToThisWorkspace;
+
+
+    public SwitchWorkspaceCommand() {
         LOGGER.setLevel(Level.WARNING);
         this.description = description;
     }
 
     @Override
     public String execute(AnimeData animeData, StorageManager storageManager, User user) throws AniException {
-        String[] paramGiven = description.split("-");
-        String result = "";
-        if (description.length() < 2) {
-            LOGGER.log(Level.WARNING, NO_PARAMETER_PROVIDED);
-            throw new AniException(NO_PARAMETER_PROVIDED);
-        }
-        for (String param : paramGiven) {
-            String[] paramParts = param.split(" ", 2);
-            switch (paramParts[0].trim()) {
-            case "": //skip the first empty param
-                break;
-            case "n": //Name of Workspace
-                paramLengthCheck(paramParts);
-                //Find the user and setActiveUser to it
-                Workspace chgWorkspace = user.getWorkspace(paramParts[1]);
-                user.setActiveWorkspace(chgWorkspace);
-                result = SWITCH_SUCCESS_HEADER + user.getHonorificName();
-                break;
-            default:
-                String invalidParameter = PARAMETER_ERROR_HEADER + param + NOT_RECOGNISED;
-                throw new AniException(invalidParameter);
-            }
-        }
+        //Find the user and setActiveUser to it
+        Workspace chgWorkspace = user.getWorkspace(switchToThisWorkspace);
+        user.setActiveWorkspace(chgWorkspace);
+        String result = SWITCH_SUCCESS_HEADER + switchToThisWorkspace;
         return result;
     }
 
-    private void paramLengthCheck(String[] paramParts) throws AniException {
-        if (paramParts.length < 2) {
-            String invalidParameter = PARAMETER_ERROR_HEADER + paramParts[0] + REQUIRE_ADDITIONAL_FIELD;
-            throw new AniException(invalidParameter);
-        }
+    public void setSwitchToThisWorkspace(String switchToThisWorkspace) {
+        this.switchToThisWorkspace = switchToThisWorkspace;
     }
 }

--- a/src/main/java/seedu/duke/human/User.java
+++ b/src/main/java/seedu/duke/human/User.java
@@ -109,14 +109,13 @@ public class User extends Human {
     }
 
     // NOTE: return null and check.
-    public Workspace getWorkspace(String name) {
+    public Workspace getWorkspace(String name) throws AniException {
         for (Workspace existingWorkspace : workspaceList) {
             if (existingWorkspace.getName().equals(name)) {
                 return existingWorkspace;
             }
         }
-
-        return null;
+        throw new AniException("Workspace " + name + " does not exist!");
     }
 
 

--- a/src/main/java/seedu/duke/parser/BrowseParser.java
+++ b/src/main/java/seedu/duke/parser/BrowseParser.java
@@ -29,6 +29,7 @@ public class BrowseParser extends CommandParser {
 
     public BrowseParser() {
         browseCommand = new BrowseCommand();
+        LOGGER.setLevel(Level.WARNING);
     }
 
     public BrowseCommand parse(String description) throws AniException {
@@ -43,8 +44,11 @@ public class BrowseParser extends CommandParser {
     private void parameterParser(String[] paramGiven) throws AniException {
         for (String param : paramGiven) {
             String[] paramParts = param.split(" ");
+            if (paramParts.length == 0) {
+                break;
+            }
             switch (paramParts[0].trim()) {
-            case "": //skip the first empty param
+            case "": //skip empty param
                 break;
             case SORT_PARAM:
                 paramFieldCheck(paramParts);

--- a/src/main/java/seedu/duke/parser/BrowseParser.java
+++ b/src/main/java/seedu/duke/parser/BrowseParser.java
@@ -1,0 +1,107 @@
+package seedu.duke.parser;
+
+import seedu.duke.command.BrowseCommand;
+import seedu.duke.exception.AniException;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class BrowseParser extends CommandParser {
+    protected static final String SORT_PARAM = "s";
+    protected static final String FILTER_PARAM = "f";
+    protected static final String ORDER_PARAM = "o";
+    protected static final String PAGE_PARAM = "p";
+    protected static final String ASCENDING_FIELD = "asc";
+    protected static final String DESCENDING_FIELD = "dsc";
+    protected static final String NAME_FIELD = "name";
+    protected static final String RATING_FIELD = "rating";
+    protected static final int ID_SORT = 0;
+    protected static final String OUT_OF_BOUND_PAGE_ERROR = "Invalid Page size!";
+    protected static final String PARAMETER_ERROR_HEADER = "Parameter : -";
+    protected static final String REQUIRE_ADDITIONAL_FIELD = " requires an additional field";
+    protected static final String INVALID_OPTION = " is not a valid option";
+    protected static final String NOT_RECOGNISED = " is not recognised!";
+    protected static final String NON_INTEGER_PROVIDED = "Please specify an Int value for page number!";
+    protected static final String BROWSE_SETTINGS_CHANGED_INFO = "Default values modified";
+    private static final Logger LOGGER = Logger.getLogger(BrowseParser.class.getName());
+
+    private BrowseCommand browseCommand;
+
+    public BrowseParser() {
+        browseCommand = new BrowseCommand();
+    }
+
+    public BrowseCommand parse(String description) throws AniException {
+        String[] paramGiven = parameterSplitter(description);
+        if (paramGiven.length > 1) {
+            parameterParser(paramGiven);
+            LOGGER.log(Level.INFO, BROWSE_SETTINGS_CHANGED_INFO);
+        }
+        return browseCommand;
+    }
+
+    private void parameterParser(String[] paramGiven) throws AniException {
+        for (String param : paramGiven) {
+            String[] paramParts = param.split(" ");
+            switch (paramParts[0].trim()) {
+            case "": //skip the first empty param
+                break;
+            case SORT_PARAM:
+                paramFieldCheck(paramParts);
+                paramExtraFieldCheck(paramParts);
+                checkSortType(paramParts);
+                break;
+            case FILTER_PARAM:
+                paramFieldCheck(paramParts);
+                paramExtraFieldCheck(paramParts);
+                browseCommand.setFilter(paramParts[1]);
+                break;
+            case ORDER_PARAM:
+                paramFieldCheck(paramParts);
+                paramExtraFieldCheck(paramParts);
+                checkOrderType(paramParts[1]);
+                break;
+            case PAGE_PARAM:
+                paramFieldCheck(paramParts);
+                paramExtraFieldCheck(paramParts);
+                if (!isInt(paramParts[1].trim())) {
+                    throw new AniException(NON_INTEGER_PROVIDED);
+                }
+                browseCommand.setPage(Integer.parseInt(paramParts[1].trim()));
+                break;
+            default:
+                String invalidParameter = PARAMETER_ERROR_HEADER + param + NOT_RECOGNISED;
+                throw new AniException(invalidParameter);
+            }
+        }
+    }
+
+    private void checkOrderType(String paramField) throws AniException {
+        switch (paramField.trim()) {
+        case ASCENDING_FIELD:
+            browseCommand.setOrder(0);
+            break;
+        case DESCENDING_FIELD:
+            browseCommand.setOrder(1);
+            break;
+        default:
+            String paramFieldError = paramField + INVALID_OPTION;
+            throw new AniException(paramFieldError);
+        }
+    }
+
+    private void checkSortType(String[] paramParts) throws AniException {
+        switch (paramParts[1].trim()) {
+        case NAME_FIELD:
+            browseCommand.setSortType(1);
+            break;
+        case RATING_FIELD:
+            browseCommand.setSortType(2);
+            break;
+        default:
+            String paramFieldError = paramParts[1] + INVALID_OPTION;
+            throw new AniException(paramFieldError);
+        }
+    }
+
+}

--- a/src/main/java/seedu/duke/parser/CommandParser.java
+++ b/src/main/java/seedu/duke/parser/CommandParser.java
@@ -65,7 +65,6 @@ public abstract class CommandParser {
      * @param checkStr the string to check
      * @return true if it can be parsed into an integer
      */
-
     public boolean isInt(String checkStr) {
         return checkStr.matches("-?\\d+(\\.\\d+)?");
     }

--- a/src/main/java/seedu/duke/parser/CommandParser.java
+++ b/src/main/java/seedu/duke/parser/CommandParser.java
@@ -1,0 +1,73 @@
+package seedu.duke.parser;
+
+import seedu.duke.exception.AniException;
+
+public abstract class CommandParser {
+    public static final String NOT_RECOGNISED = " is not recognised!";
+    protected static final String PARAMETER_ERROR_HEADER = "Parameter : -";
+    protected static final String REQUIRE_ADDITIONAL_FIELD = " requires an additional field";
+    protected static final String TOO_MUCH_FIELDS = " has too much fields";
+    protected static final String NO_PARAMETER_PROVIDED = "No Parameter provided";
+
+    /**
+     * Splits the parameters into individual parts for parsing.
+     *
+     * @param parameter unprocessed parameter strings
+     * @return parameters in parts
+     */
+    public String[] parameterSplitter(String parameter) {
+        return parameter.split("-");
+    }
+
+    /**
+     * Checks if there is a parameter set.
+     *
+     * @param paramParts Array of parameters
+     * @throws AniException if there is no parameter provided
+     */
+
+    public void paramIsSetCheck(String[] paramParts) throws AniException {
+        if (paramParts.length < 2) {
+            throw new AniException(NO_PARAMETER_PROVIDED);
+        }
+    }
+
+    /**
+     * Checks if parameter has a single additional field or not.
+     *
+     * @param paramParts the param to check
+     * @throws AniException if the parameter is missing the additional field
+     */
+    public void paramFieldCheck(String[] paramParts) throws AniException {
+        if (paramParts.length < 2) {
+            String invalidParameter = PARAMETER_ERROR_HEADER + paramParts[0] + REQUIRE_ADDITIONAL_FIELD;
+            throw new AniException(invalidParameter);
+        }
+    }
+
+    /**
+     * Checks if parameter has more than one field.
+     *
+     * @param paramParts the param to check
+     * @throws AniException if the parameter has too many fields
+     */
+    public void paramExtraFieldCheck(String[] paramParts) throws AniException {
+        if (paramParts.length > 2) {
+            String invalidParameter = PARAMETER_ERROR_HEADER + paramParts[0] + TOO_MUCH_FIELDS;
+            throw new AniException(invalidParameter);
+        }
+    }
+
+
+    /**
+     * Checks if the string is an integer.
+     *
+     * @param checkStr the string to check
+     * @return true if it can be parsed into an integer
+     */
+
+    public boolean isInt(String checkStr) {
+        return checkStr.matches("-?\\d+(\\.\\d+)?");
+    }
+
+}

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -1,14 +1,12 @@
 package seedu.duke.parser;
 
-import seedu.duke.command.Command;
-import seedu.duke.command.AddWorkspaceCommand;
-import seedu.duke.command.SwitchWorkspaceCommand;
-import seedu.duke.command.BrowseCommand;
-import seedu.duke.command.WatchlistCommand;
 import seedu.duke.command.AddToWatchlistCommand;
+import seedu.duke.command.AddWorkspaceCommand;
 import seedu.duke.command.BookmarkAnimeCommand;
-import seedu.duke.command.HelpCommand;
+import seedu.duke.command.Command;
 import seedu.duke.command.ExitCommand;
+import seedu.duke.command.HelpCommand;
+import seedu.duke.command.WatchlistCommand;
 import seedu.duke.exception.AniException;
 
 import java.util.logging.Level;
@@ -33,28 +31,28 @@ public class Parser {
         switch (command) {
         case "adduser":
             return new AddWorkspaceCommand(description);
-                
+
         case "switchuser":
-            return new SwitchWorkspaceCommand(description);
- 
+            return new SwitchWorkspaceParser().parse(description);
+
         case "browse":
-            return new BrowseCommand(description);
-     
+            return new BrowseParser().parse(description);
+
         case "watchlist":
             return new WatchlistCommand(description);
-           
+
         case "add":
             return new AddToWatchlistCommand(description);
 
         case "bookmark":
             return new BookmarkAnimeCommand(description);
-                
+
         case "help":
             return new HelpCommand();
 
         case "exit":
             return new ExitCommand();
-                
+
         default:
             throw new AniException("Unknown command");
         }

--- a/src/main/java/seedu/duke/parser/SwitchWorkspaceParser.java
+++ b/src/main/java/seedu/duke/parser/SwitchWorkspaceParser.java
@@ -20,6 +20,9 @@ public class SwitchWorkspaceParser extends CommandParser {
     public void parameterParser(String[] paramGiven) throws AniException {
         for (String param : paramGiven) {
             String[] paramParts = param.split(" ", 2);
+            if (paramParts.length == 0) {
+                break;
+            }
             switch (paramParts[0].trim()) {
             case "": //skip the first empty param
                 break;

--- a/src/main/java/seedu/duke/parser/SwitchWorkspaceParser.java
+++ b/src/main/java/seedu/duke/parser/SwitchWorkspaceParser.java
@@ -1,0 +1,36 @@
+package seedu.duke.parser;
+
+import seedu.duke.command.SwitchWorkspaceCommand;
+import seedu.duke.exception.AniException;
+
+public class SwitchWorkspaceParser extends CommandParser {
+    private final SwitchWorkspaceCommand switchWorkspaceCommand;
+
+    public SwitchWorkspaceParser() {
+        switchWorkspaceCommand = new SwitchWorkspaceCommand();
+    }
+
+    public SwitchWorkspaceCommand parse(String description) throws AniException {
+        String[] paramGiven = parameterSplitter(description);
+        paramIsSetCheck(paramGiven);
+        parameterParser(paramGiven);
+        return switchWorkspaceCommand;
+    }
+
+    public void parameterParser(String[] paramGiven) throws AniException {
+        for (String param : paramGiven) {
+            String[] paramParts = param.split(" ", 2);
+            switch (paramParts[0].trim()) {
+            case "": //skip the first empty param
+                break;
+            case "n": //Name of Workspace
+                paramFieldCheck(paramParts);
+                switchWorkspaceCommand.setSwitchToThisWorkspace(paramParts[1]);
+                break;
+            default:
+                String invalidParameter = PARAMETER_ERROR_HEADER + param + NOT_RECOGNISED;
+                throw new AniException(invalidParameter);
+            }
+        }
+    }
+}

--- a/src/test/java/seedu/duke/command/BrowseCommandTest.java
+++ b/src/test/java/seedu/duke/command/BrowseCommandTest.java
@@ -1,111 +1,32 @@
 package seedu.duke.command;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import seedu.duke.anime.Anime;
-import seedu.duke.anime.AnimeData;
 import seedu.duke.exception.AniException;
-import seedu.duke.human.User;
-import seedu.duke.storage.StorageManager;
-
-import java.util.ArrayList;
+import seedu.duke.parser.BrowseParser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class BrowseCommandTest {
-    AnimeData animeData;
-    User user;
-    StorageManager storageManager;
+public class BrowseCommandTest {
 
-    protected static final String INVALID_PARAMETERS_TEST1 = "-n name";
-    protected static final String INVALID_PARAMETERS_TEST2 = "-sort name";
-    protected static final String INVALID_FIELD_TEST1 = "-s   ";
-    protected static final String INVALID_FIELD_TEST2 = "-s beepboopbeep";
-    protected static final String INVALID_FIELD_TEST3 = "-s -o -p";
     protected static final String LARGE_PAGE_NUM = "-p 9999";
     protected static final String NEGATIVE_PAGE_NUM = "-p -1";
     protected static final String ZERO_PAGE_NUM = "-p 0";
-    protected static final String DIFF_ORDER_TEST = "-p 1 -s rating -o asc";
-    protected static final String DIFF_ORDER_TEST2 = "-s rating -o asc -p 1";
-    protected static final String NO_PARAM_TEST = "";
-
-    @BeforeEach
-    void setUp() {
-        ArrayList<Anime> testList = new ArrayList<Anime>();
-        Anime testAnime1 = new Anime();
-        Anime testAnime2 = new Anime();
-        testList.add(testAnime1);
-        testList.add(testAnime2);
-        animeData = new AnimeData(testList);
-        storageManager = new StorageManager();
-    }
 
     @Test
-    void execute_invalidParameter_ThrowsAniException() {
-        BrowseCommand testBrowse = new BrowseCommand(INVALID_PARAMETERS_TEST1);
+    void parse_invalidPageNum_ThrowsAniException() throws AniException {
+        BrowseParser testParse = new BrowseParser();
         assertThrows(AniException.class, () -> {
-            testBrowse.execute(animeData, storageManager, user);
+            testParse.parse(LARGE_PAGE_NUM);
         });
 
-        BrowseCommand testBrowse2 = new BrowseCommand(INVALID_PARAMETERS_TEST2);
+        BrowseParser testParse2 = new BrowseParser();
         assertThrows(AniException.class, () -> {
-            testBrowse2.execute(animeData, storageManager, user);
-        });
-    }
-
-    @Test
-    void execute_invalidField_ThrowsAniException() {
-        BrowseCommand testBrowse = new BrowseCommand(INVALID_FIELD_TEST1);
-        assertThrows(AniException.class, () -> {
-            testBrowse.execute(animeData, storageManager, user);
+            testParse2.parse(NEGATIVE_PAGE_NUM);
         });
 
-        BrowseCommand testBrowse2 = new BrowseCommand(INVALID_FIELD_TEST2);
-        assertThrows(AniException.class, () -> {
-            testBrowse2.execute(animeData, storageManager, user);
-        });
-
-        BrowseCommand testBrowse3 = new BrowseCommand(INVALID_FIELD_TEST3);
-        assertThrows(AniException.class, () -> {
-            testBrowse3.execute(animeData, storageManager, user);
-        });
-    }
-
-    @Test
-    void execute_invalidPageNum_ThrowsAniException() {
-        BrowseCommand testBrowse = new BrowseCommand(LARGE_PAGE_NUM);
-        assertThrows(AniException.class, () -> {
-            testBrowse.execute(animeData, storageManager, user);
-        });
-
-        BrowseCommand testBrowse2 = new BrowseCommand(NEGATIVE_PAGE_NUM);
-        assertThrows(AniException.class, () -> {
-            testBrowse2.execute(animeData, storageManager, user);
-        });
-
-        BrowseCommand testBrowse3 = new BrowseCommand(ZERO_PAGE_NUM);
-        assertEquals(testBrowse3.getPage(), 1);
-    }
-
-    @Test
-    void execute_differentParameterOrder_identicalBrowseSettings() {
-        BrowseCommand testBrowse = new BrowseCommand(DIFF_ORDER_TEST);
-        BrowseCommand testBrowse2 = new BrowseCommand(DIFF_ORDER_TEST2);
-
-        assertEquals(testBrowse.getPage(), testBrowse2.getPage());
-        assertEquals(testBrowse.getSortType(), testBrowse2.getSortType());
-        assertEquals(testBrowse.getOrder(), testBrowse2.getOrder());
-
-    }
-
-    @Test
-    void execute_noParam_identicalBrowseSettings() {
-        BrowseCommand testBrowse = new BrowseCommand(NO_PARAM_TEST);
-
-        //Performs test against default settings
+        BrowseParser testParse3 = new BrowseParser();
+        BrowseCommand testBrowse = testParse3.parse(ZERO_PAGE_NUM);
         assertEquals(testBrowse.getPage(), 1);
-        assertEquals(testBrowse.getSortType(), 0);
-        assertEquals(testBrowse.getOrder(), 1);
     }
 }

--- a/src/test/java/seedu/duke/command/BrowseCommandTest.java
+++ b/src/test/java/seedu/duke/command/BrowseCommandTest.java
@@ -1,32 +1,52 @@
 package seedu.duke.command;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import seedu.duke.anime.Anime;
+import seedu.duke.anime.AnimeData;
 import seedu.duke.exception.AniException;
+import seedu.duke.human.User;
 import seedu.duke.parser.BrowseParser;
+import seedu.duke.storage.StorageManager;
+
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BrowseCommandTest {
+    AnimeData animeData;
+    User user;
+    StorageManager storageManager;
 
     protected static final String LARGE_PAGE_NUM = "-p 9999";
     protected static final String NEGATIVE_PAGE_NUM = "-p -1";
     protected static final String ZERO_PAGE_NUM = "-p 0";
 
+    @BeforeEach
+    void setUp() {
+        ArrayList<Anime> testList = new ArrayList<Anime>();
+        Anime testAnime1 = new Anime();
+        Anime testAnime2 = new Anime();
+        testList.add(testAnime1);
+        testList.add(testAnime2);
+        animeData = new AnimeData(testList);
+        storageManager = new StorageManager();
+    }
+
     @Test
-    void parse_invalidPageNum_ThrowsAniException() throws AniException {
+    void execute_invalidPageNum_ThrowsAniException() throws AniException {
         BrowseParser testParse = new BrowseParser();
+        BrowseCommand testBrowse = testParse.parse(LARGE_PAGE_NUM);
         assertThrows(AniException.class, () -> {
-            testParse.parse(LARGE_PAGE_NUM);
+            testBrowse.execute(animeData, storageManager, user);
         });
 
-        BrowseParser testParse2 = new BrowseParser();
         assertThrows(AniException.class, () -> {
-            testParse2.parse(NEGATIVE_PAGE_NUM);
+            testParse.parse(NEGATIVE_PAGE_NUM);
         });
 
-        BrowseParser testParse3 = new BrowseParser();
-        BrowseCommand testBrowse = testParse3.parse(ZERO_PAGE_NUM);
-        assertEquals(testBrowse.getPage(), 1);
+        BrowseCommand testBrowse2 = testParse.parse(ZERO_PAGE_NUM);
+        assertEquals(testBrowse2.getPage(), 1);
     }
 }

--- a/src/test/java/seedu/duke/parser/BrowseParserTest.java
+++ b/src/test/java/seedu/duke/parser/BrowseParserTest.java
@@ -1,0 +1,93 @@
+package seedu.duke.parser;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.duke.anime.Anime;
+import seedu.duke.anime.AnimeData;
+import seedu.duke.command.BrowseCommand;
+import seedu.duke.exception.AniException;
+import seedu.duke.human.User;
+import seedu.duke.storage.StorageManager;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BrowseParserTest {
+    AnimeData animeData;
+    User user;
+    StorageManager storageManager;
+
+    protected static final String INVALID_PARAMETERS_TEST1 = "-n name";
+    protected static final String INVALID_PARAMETERS_TEST2 = "-sort name";
+    protected static final String INVALID_FIELD_TEST1 = "-s   ";
+    protected static final String INVALID_FIELD_TEST2 = "-s beepboopbeep";
+    protected static final String INVALID_FIELD_TEST3 = "-s -o -p";
+    protected static final String DIFF_ORDER_TEST = "-p 1 -s rating -o asc";
+    protected static final String DIFF_ORDER_TEST2 = "-s rating -o asc -p 1";
+    protected static final String NO_PARAM_TEST = "";
+
+    @BeforeEach
+    void setUp() {
+        ArrayList<Anime> testList = new ArrayList<Anime>();
+        Anime testAnime1 = new Anime();
+        Anime testAnime2 = new Anime();
+        testList.add(testAnime1);
+        testList.add(testAnime2);
+        animeData = new AnimeData(testList);
+        storageManager = new StorageManager();
+    }
+
+    @Test
+    void parse_invalidParameter_ThrowsAniException() {
+        BrowseParser testParse = new BrowseParser();
+        assertThrows(AniException.class, () -> {
+            testParse.parse(INVALID_PARAMETERS_TEST1);
+        });
+
+        assertThrows(AniException.class, () -> {
+            testParse.parse(INVALID_PARAMETERS_TEST2);
+        });
+    }
+
+    @Test
+    void parse_invalidField_ThrowsAniException() {
+        BrowseParser testParse = new BrowseParser();
+        assertThrows(AniException.class, () -> {
+            testParse.parse(INVALID_FIELD_TEST1);
+        });
+
+        BrowseParser testParse2 = new BrowseParser();
+        assertThrows(AniException.class, () -> {
+            testParse.parse(INVALID_FIELD_TEST2);
+        });
+
+        BrowseParser testParse3 = new BrowseParser();
+        assertThrows(AniException.class, () -> {
+            testParse.parse(INVALID_FIELD_TEST3);
+        });
+    }
+
+    @Test
+    void parse_differentParameterOrder_identicalBrowseSettings() throws AniException {
+        BrowseParser testParse = new BrowseParser();
+        BrowseCommand testBrowse = testParse.parse(DIFF_ORDER_TEST);
+        BrowseCommand testBrowse2 = testParse.parse(DIFF_ORDER_TEST2);
+
+        assertEquals(testBrowse.getPage(), testBrowse2.getPage());
+        assertEquals(testBrowse.getSortType(), testBrowse2.getSortType());
+        assertEquals(testBrowse.getOrder(), testBrowse2.getOrder());
+    }
+
+    @Test
+    void parse_noParam_identicalBrowseSettings() throws AniException {
+        BrowseParser testParse = new BrowseParser();
+        BrowseCommand testBrowse = testParse.parse(NO_PARAM_TEST);
+
+        //Performs test against default settings
+        assertEquals(testBrowse.getPage(), 1);
+        assertEquals(testBrowse.getSortType(), 0);
+        assertEquals(testBrowse.getOrder(), 1);
+    }
+}

--- a/src/test/java/seedu/duke/parser/BrowseParserTest.java
+++ b/src/test/java/seedu/duke/parser/BrowseParserTest.java
@@ -80,14 +80,4 @@ class BrowseParserTest {
         assertEquals(testBrowse.getOrder(), testBrowse2.getOrder());
     }
 
-    @Test
-    void parse_noParam_identicalBrowseSettings() throws AniException {
-        BrowseParser testParse = new BrowseParser();
-        BrowseCommand testBrowse = testParse.parse(NO_PARAM_TEST);
-
-        //Performs test against default settings
-        assertEquals(testBrowse.getPage(), 1);
-        assertEquals(testBrowse.getSortType(), 0);
-        assertEquals(testBrowse.getOrder(), 1);
-    }
 }

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -42,7 +42,7 @@ Default (Default) #> Successfully added new workspace:
 Default (Default) #> Successfully added new workspace:
  Workspace: Testing2
 
-Default (Default) #> Welcome back, Abec Steiner 33rd-chan
+Default (Default) #> Workspace changed to Testing1
 
 Testing1 (Default) #> Anime added to watchlist!
 
@@ -56,6 +56,6 @@ Testing1 (Default) #> Listing all anime in bookmark:
 	Uhh.. It's empty.. :(
 
 
-Testing1 (Default) #> Welcome back, Abec Steiner 33rd-chan
+Testing1 (Default) #> Workspace changed to Testing2
 
 Testing2 (Default) #> Sayonara Abec Steiner 33rd-chan!


### PR DESCRIPTION
Add:
- CommandParser class to have utility methods
- BrowseParser and SwitchWorkspaceParser
- BrowseParserTest and moved input validation test here
Update
- BrowseCommand, SwitchWorkspaceCommand
- Parser, BrowseCommandTest, EXPECTED.txt to reflect changes
- User.java with minor getUser fix

@AY2021S1-CS2113T-F12-2/developers do note:
- You can now move your commands parameter parsing to a new class which inherits from CommandParser.
- I hope you would utilise the utility methods that I have created to avoid code duplication!
- parameterSplitter: takes in the raw string and returns a string array split by "-"
- paramIsSetCheck: checks if the split parameter array contains a parameter 
   example: will throw "switchuser"
   example: will not throw "switchuser -n alpha"
- paramFieldCheck: checks if the parameter has an additional field or not
  example: will throw:  "-a"
  example: will not throw: "-a alpha" or "-b beta charlie"
- paramExtraFieldCheck: Checks if the parameter has more than one field.
  example: will throw: "-a alpha beta"
  example: will not throw: "-a alpha"
- isInt: checks if a String can be parsed into an int value or not. 
  Returns true if able to. 
  Returns false if not

Thank you!
Closes #122 